### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![License](https://img.shields.io/badge/license-MIT%20License-lightgrey.svg)](https://github.com/phpmaple/Stick-Hero-Swift/blob/master/LICENSE)
 
 # Stick-Hero-Swift
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=56576f5c28898101003ae8c4&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/56576f5c28898101003ae8c4/build/latest)
+
 a universal iOS Game using Swift 2 and iOS SpriteKit.
 
 # Requirements


### PR DESCRIPTION
We really liked Stick Hero on Github and wanted to offer you a free continuous integration system [(buddybuild)](buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/56576f5c28898101003ae8c4/build/latest) are the builds we've completed for Stick Hero so far.

![screen shot 2015-11-26 at 12 57 51 pm](https://cloud.githubusercontent.com/assets/13876667/11430576/9732c59e-943d-11e5-95c4-b12b4cbbbc5f.png)

To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here] (dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.